### PR TITLE
Fix documentation for iconAttributes

### DIFF
--- a/source/Ui.elm
+++ b/source/Ui.elm
@@ -24,7 +24,7 @@ icon : String -> Bool -> List Html.Attribute -> Html.Html
 icon glyph clickable attributes =
   node "ui-icon" (iconAttributes glyph clickable attributes) []
 
-{- Attributes for icons. -}
+{-| Attributes for icons. -}
 iconAttributes : String -> Bool -> List Html.Attribute -> List Html.Attribute
 iconAttributes glyph clickable attributes =
   let


### PR DESCRIPTION
Missing `|` caused elm-make to not see the documentation comment.

``` bash
-- DOCUMENTATION ERROR ----------------------------------------- ./source/Ui.elm

The value `iconAttributes` does not have a documentation comment.

29│ iconAttributes glyph clickable attributes =
    ^^^^^^^^^^^^^^
Learn more at <http://package.elm-lang.org/help/documentation-format>

Detected errors in 1 module.
```
