### PR TITLE
Fix typo in documentation

### DIFF
--- a/source/Ui/NumberRange.elm
+++ b/source/Ui/NumberRange.elm
@@ -206,7 +206,7 @@ render address model =
       ]
       [ focusedInput ]
 
-{-| Focused the component. -}
+{-| Focuses the component. -}
 focus : Model -> Model
 focus model =
   case model.focused of


### PR DESCRIPTION
Past -> present tense
