### PR TITLE
Ability to set path prefix at the server command using -p, --path [pa…

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -45,10 +45,14 @@ program
 
 program
   .command('server')
+  .option('-p, --prefix [prefix]', 'path prefix')
   .alias('start')
   .description('Starts development server')
   .action(function(env, opts) {
-    elmUi.serve(options())
+    elmUi.serve({
+      env: program.env,
+      prefix: env.prefix
+    })
   })
 
 program

--- a/bin/lib/command/serve.js
+++ b/bin/lib/command/serve.js
@@ -1,6 +1,6 @@
 var browserSync = require('browser-sync').create()
-var router = require('koa-router')()
 var serve = require('koa-static')
+var koaRouter = require('koa-router')
 var path = require('path')
 var app = require('koa')()
 
@@ -12,6 +12,7 @@ var readConfig = require('./read-config')
 
 module.exports = function(options) {
   var config = readConfig(options)
+  var router = new koaRouter({prefix: options.prefix})
 
   browserSync.watch("source/**/*.elm").on("change", browserSync.reload)
 


### PR DESCRIPTION
…th] option

`elm-ui start -p '/ui`' would cause the the UI to serve at http://localhost:8002/ui/
