### PR TITLE
Tweaked the chooser rendering to not render children unless it's open…

### DIFF
--- a/source/Ui/Chooser.elm
+++ b/source/Ui/Chooser.elm
@@ -234,7 +234,10 @@ render : Model -> Html.Html Msg
 render model =
   let
     children =
-      (List.map (renderItem model) (items model))
+      if model.open then
+        (List.map (renderItem model) (items model))
+      else
+        []
 
     dropdown =
       [ Dropdown.view


### PR DESCRIPTION
…. Greatly improves performance when you have multiple dynamic choosers.

Understand that you may want to implement this differently, or not at all, but we needed to fork for our project anyways, so I figured I'd PR it so it doesn't get lost.