### PR TITLE
Removed all global styles

### DIFF
--- a/bin/assets/scaffold/stylesheets/main.scss
+++ b/bin/assets/scaffold/stylesheets/main.scss
@@ -1,5 +1,10 @@
 @import 'ui';
 
+body {
+  background: $background;
+  margin: 0;
+}
+
 ui-app > ui-container {
   padding-top: 60px;
   max-width: 900px;

--- a/stylesheets/ui/components/ui-app.scss
+++ b/stylesheets/ui/components/ui-app.scss
@@ -4,10 +4,8 @@
 ui-app {
   display: block;
   color: readable($background);
-  background: $background;
   font-family: Open Sans;
   font-size: 16px;
-  margin: 0;
 
   * {
     -webkit-touch-callout: none;

--- a/stylesheets/ui/components/ui-app.scss
+++ b/stylesheets/ui/components/ui-app.scss
@@ -1,3 +1,16 @@
+@import '../lib/functions';
+@import '../lib/variables';
+
 ui-app {
   display: block;
+  color: readable($background);
+  background: $background;
+  font-family: Open Sans;
+  font-size: 16px;
+  margin: 0;
+
+  * {
+    -webkit-touch-callout: none;
+    box-sizing: border-box;
+  }
 }

--- a/stylesheets/ui/ui.scss
+++ b/stylesheets/ui/ui.scss
@@ -49,19 +49,6 @@
 @import 'components/ui-layout';
 @import 'components/ui-file-input';
 
-* {
-  -webkit-touch-callout: none;
-  box-sizing: border-box;
-}
-
 html {
   -webkit-tap-highlight-color: rgba(#000, 0);
-}
-
-body {
-  color: readable($background);
-  background: $background;
-  font-family: Open Sans;
-  font-size: 16px;
-  margin: 0;
 }


### PR DESCRIPTION
I removed globally scoped css since all elm ui apps should be using Ui.App as an entry point. I made this change because it was overriding some styles in a web app we embedded our elm-ui app inside of.