### PR TITLE
CHANGE nest Css module under Ui namespace

### DIFF
--- a/source/Ui/Css.elm
+++ b/source/Ui/Css.elm
@@ -1,4 +1,4 @@
-module Css exposing (..)
+module Ui.Css exposing (..)
 
 import Html exposing (text)
 import Regex

--- a/source/Ui/Css/Properties.elm
+++ b/source/Ui/Css/Properties.elm
@@ -1,6 +1,6 @@
-module Css.Properties exposing (..)
+module Ui.Css.Properties exposing (..)
 
-import Css exposing (Node, property)
+import Ui.Css exposing (Node, property)
 
 type alias Transition =
   { easing : String
@@ -498,7 +498,7 @@ maxWidth =
 
 userSelect : String -> Node
 userSelect value =
-  Css.mixin
+  Ui.Css.mixin
     [ property "-webkit-user-select" value
     , property "-moz-user-select" value
     , property "-ms-user-select" value

--- a/source/Ui/Styles.elm
+++ b/source/Ui/Styles.elm
@@ -7,7 +7,7 @@ module Ui.Styles exposing (Style, apply, attributes)
 import Html.Attributes exposing (attribute)
 import Html
 
-import Css exposing (Node, resolve)
+import Ui.Css exposing (Node, resolve)
 import Lazy exposing (Lazy)
 import Json.Encode as Json
 import Native.Styles
@@ -52,6 +52,6 @@ attributes node =
       id = Murmur3.hashString 0 (toString node)
     in
       { value =
-          resolve [ Css.selector ("[style-id='" ++ (toString id) ++ "']") [ node ] ]
+          resolve [ Ui.Css.selector ("[style-id='" ++ (toString id) ++ "']") [ node ] ]
       , id = id
       }

--- a/source/Ui/Styles/Breadcrumbs.elm
+++ b/source/Ui/Styles/Breadcrumbs.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Breadcrumbs exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Button.elm
+++ b/source/Ui/Styles/Button.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Button exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Ripple as Ripple

--- a/source/Ui/Styles/ButtonGroup.elm
+++ b/source/Ui/Styles/ButtonGroup.elm
@@ -4,8 +4,8 @@ module Ui.Styles.ButtonGroup exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Calendar.elm
+++ b/source/Ui/Styles/Calendar.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Calendar exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Checkbox.elm
+++ b/source/Ui/Styles/Checkbox.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Checkbox exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Chooser.elm
+++ b/source/Ui/Styles/Chooser.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Chooser exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/ColorFields.elm
+++ b/source/Ui/Styles/ColorFields.elm
@@ -4,8 +4,8 @@ module Ui.Styles.ColorFields exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/ColorPanel.elm
+++ b/source/Ui/Styles/ColorPanel.elm
@@ -4,8 +4,8 @@ module Ui.Styles.ColorPanel exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/ColorPicker.elm
+++ b/source/Ui/Styles/ColorPicker.elm
@@ -4,8 +4,8 @@ module Ui.Styles.ColorPicker exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Picker as Picker

--- a/source/Ui/Styles/Container.elm
+++ b/source/Ui/Styles/Container.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Container exposing (style, defaultStyle)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles exposing (Style)

--- a/source/Ui/Styles/DatePicker.elm
+++ b/source/Ui/Styles/DatePicker.elm
@@ -4,8 +4,8 @@ module Ui.Styles.DatePicker exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Picker as Picker

--- a/source/Ui/Styles/Dropdown.elm
+++ b/source/Ui/Styles/Dropdown.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Dropdown exposing (..)
 
 @docs style
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/DropdownMenu.elm
+++ b/source/Ui/Styles/DropdownMenu.elm
@@ -4,8 +4,8 @@ module Ui.Styles.DropdownMenu exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Fab.elm
+++ b/source/Ui/Styles/Fab.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Fab exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/FileInput.elm
+++ b/source/Ui/Styles/FileInput.elm
@@ -4,8 +4,8 @@ module Ui.Styles.FileInput exposing (..)
 
 @docs style, styleDetails, defaultStyle, defaultStyleDetails
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Header.elm
+++ b/source/Ui/Styles/Header.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Header exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/IconButton.elm
+++ b/source/Ui/Styles/IconButton.elm
@@ -4,8 +4,8 @@ module Ui.Styles.IconButton exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Button as Button

--- a/source/Ui/Styles/Image.elm
+++ b/source/Ui/Styles/Image.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Image exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles exposing (Style)

--- a/source/Ui/Styles/InplaceInput.elm
+++ b/source/Ui/Styles/InplaceInput.elm
@@ -4,8 +4,8 @@ module Ui.Styles.InplaceInput exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Input.elm
+++ b/source/Ui/Styles/Input.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Input exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Layout.elm
+++ b/source/Ui/Styles/Layout.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Layout exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Loader.elm
+++ b/source/Ui/Styles/Loader.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Loader exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Mixins.elm
+++ b/source/Ui/Styles/Mixins.elm
@@ -5,8 +5,8 @@ module Ui.Styles.Mixins exposing (..)
 @docs placeholder, defaults, focused, focusedIdle, ellipsis, disabled
 @docs disabledColors, disabledCursor, readonlyCursor, readonly
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Regex
@@ -74,7 +74,7 @@ focused theme =
 ellipsis : Node
 ellipsis =
   mixin
-    [ textOverflow Css.Properties.ellipsis
+    [ textOverflow Ui.Css.Properties.ellipsis
     , whiteSpace nowrap
     , overflow hidden
     ]

--- a/source/Ui/Styles/Modal.elm
+++ b/source/Ui/Styles/Modal.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Modal exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/NotificationCenter.elm
+++ b/source/Ui/Styles/NotificationCenter.elm
@@ -4,8 +4,8 @@ module Ui.Styles.NotificationCenter exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/NumberPad.elm
+++ b/source/Ui/Styles/NumberPad.elm
@@ -4,8 +4,8 @@ module Ui.Styles.NumberPad exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/NumberRange.elm
+++ b/source/Ui/Styles/NumberRange.elm
@@ -4,8 +4,8 @@ module Ui.Styles.NumberRange exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Pager.elm
+++ b/source/Ui/Styles/Pager.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Pager exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Picker.elm
+++ b/source/Ui/Styles/Picker.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Picker exposing (..)
 
 @docs style
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Dropdown as Dropdown

--- a/source/Ui/Styles/Ratings.elm
+++ b/source/Ui/Styles/Ratings.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Ratings exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Ripple.elm
+++ b/source/Ui/Styles/Ripple.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Ripple exposing (style)
 
 @docs style
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 {-| Returns the style node for the ripple effect.
 -}

--- a/source/Ui/Styles/ScrolledPanel.elm
+++ b/source/Ui/Styles/ScrolledPanel.elm
@@ -4,8 +4,8 @@ module Ui.Styles.ScrolledPanel exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles exposing (Style)

--- a/source/Ui/Styles/SearchInput.elm
+++ b/source/Ui/Styles/SearchInput.elm
@@ -4,8 +4,8 @@ module Ui.Styles.SearchInput exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Slider.elm
+++ b/source/Ui/Styles/Slider.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Slider exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Tabs.elm
+++ b/source/Ui/Styles/Tabs.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Tabs exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Tagger.elm
+++ b/source/Ui/Styles/Tagger.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Tagger exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Textarea.elm
+++ b/source/Ui/Styles/Textarea.elm
@@ -4,8 +4,8 @@ module Ui.Styles.Textarea exposing (..)
 
 @docs style, defaultStyle
 -}
-import Css.Properties exposing (..)
-import Css exposing (..)
+import Ui.Css.Properties exposing (..)
+import Ui.Css exposing (..)
 
 import Ui.Styles.Theme as Theme exposing (Theme)
 import Ui.Styles.Mixins as Mixins

--- a/source/Ui/Styles/Theme.elm
+++ b/source/Ui/Styles/Theme.elm
@@ -5,7 +5,7 @@ module Ui.Styles.Theme exposing (..)
 @docs Theme, default
 -}
 
-import Css.Properties exposing (..)
+import Ui.Css.Properties exposing (..)
 
 {-| Representation of a theme.
 -}


### PR DESCRIPTION
Nest Css modules under Ui namespace to prevent the `elm-css` package from clashing module names.

fixes https://github.com/gdotdesign/elm-ui/issues/61