### PR TITLE
Add short hex format support to ColorFields

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -71,7 +71,7 @@
     "Ui"
   ],
   "dependencies": {
-    "eskimoblood/elm-color-extra": "3.2.3 <= v < 4.0.0",
+    "eskimoblood/elm-color-extra": "5.0.0 <= v < 6.0.0",
     "elm-community/maybe-extra": "3.0.0 <= v < 4.0.0",
     "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
     "coreytrampe/elm-vendor": "2.0.3 <= v < 3.0.0",

--- a/source/Ui/ColorFields.elm
+++ b/source/Ui/ColorFields.elm
@@ -140,7 +140,7 @@ update msg_ ({ inputs } as model) =
       let
         updatedModel =
           case Color.Convert.hexToColor inputs.hex of
-            Just color ->
+            Ok color ->
               let
                 alpha =
                   Ext.Color.hsvToRgb model.value
@@ -153,7 +153,7 @@ update msg_ ({ inputs } as model) =
               in
                 { model | value = value }
 
-            Nothing ->
+            Err _ ->
               model
       in
         setInputs updatedModel

--- a/spec/Ui/ColorFieldsSpec.elm
+++ b/spec/Ui/ColorFieldsSpec.elm
@@ -113,6 +113,21 @@ specs =
             , text = "0"
             }
           ]
+        , it "handles short hex values"
+            [ setField 1 "AB0" "#AABB00"
+            , assert.valueEquals
+              { selector = "ui-color-fields-column:nth-child(2) input"
+              , text = "170"
+              }
+            , assert.valueEquals
+              { selector = "ui-color-fields-column:nth-child(3) input"
+              , text = "187"
+              }
+            , assert.valueEquals
+              { selector = "ui-color-fields-column:nth-child(4) input"
+              , text = "0"
+              }
+            ]
         ]
       , context "alpha"
         [ context "negative number"


### PR DESCRIPTION
[Here](https://github.com/eskimoblood/elm-color-extra/pull/16) I added support for short hex format (like `#ff0`) to [elm-color-extra](https://github.com/eskimoblood/elm-color-extra), so I updated it's version in elm-package.json and writed spec