### PR TITLE
Chooser empty content

### DIFF
--- a/source/Ui/Chooser.elm
+++ b/source/Ui/Chooser.elm
@@ -92,7 +92,7 @@ type alias Model =
   , renderWhenClosed : Bool
   , selected : Set String
   , placeholder : String
-  , emptyContent : String
+  , emptyContent : Html.Html Msg
   , closeOnSelect : Bool
   , deselectable : Bool
   , intended : String
@@ -138,7 +138,7 @@ init _ =
   , deselectable = False
   , selected = Set.empty
   , placeholder = ""
-  , emptyContent = "No items to display!"
+  , emptyContent = text "No items to display!"
   , searchable = False
   , multiple = False
   , disabled = False
@@ -173,7 +173,7 @@ placeholder value model =
 
 {-| Sets the text for when there are no items to display.
 -}
-emptyContent : String -> Model -> Model
+emptyContent : Html.Html Msg -> Model -> Model
 emptyContent value model =
   { model | emptyContent = value }
 
@@ -315,10 +315,14 @@ view model =
 render : Model -> Html.Html Msg
 render model =
   let
-    children =
+    children = 
       if model.dropdown.open || (not model.dropdown.open && model.renderWhenClosed) then
-        (List.map (Html.Lazy.lazy2 renderItem model) (items_ model))
-      else
+        if List.length (items_ model) > 0 then
+           (List.map (Html.Lazy.lazy2 renderItem model) (items_ model))
+        else
+          [ node "ui-chooser-empty-content" [] [ model.emptyContent ]
+          ]
+      else  
         []
 
     val =
@@ -367,7 +371,7 @@ render model =
             , ( "disabled", model.disabled )
             , ( "readonly", model.readonly )
             ]
-          , Ui.Styles.apply (defaultStyle model.emptyContent)
+          , Ui.Styles.apply defaultStyle
           ]
           |> List.concat
         )

--- a/source/Ui/Chooser.elm
+++ b/source/Ui/Chooser.elm
@@ -1,8 +1,9 @@
 module Ui.Chooser exposing
   ( Model, Item, Msg, init, onChange, update, view, render, subscriptions
   , close, toggleItem, getFirstSelected, updateData, selectFirst, setValue
-  , placeholder, closeOnSelect, deselectable, searchable, multiple, items
-  , renderWhenClosed )
+  , placeholder, emptyContent, closeOnSelect, deselectable, searchable
+  , multiple, items, renderWhenClosed
+  )
 
 {-| This is a component for selecting a single / multiple items
 form a list of choices, with lots of options.
@@ -14,7 +15,7 @@ form a list of choices, with lots of options.
 @docs onChange
 
 # DSL
-@docs placeholder, closeOnSelect, deselectable, searchable, multiple, items
+@docs placeholder, emptyContent, closeOnSelect, deselectable, searchable, multiple, items
 @docs renderWhenClosed
 
 # View
@@ -91,6 +92,7 @@ type alias Model =
   , renderWhenClosed : Bool
   , selected : Set String
   , placeholder : String
+  , emptyContent : String
   , closeOnSelect : Bool
   , deselectable : Bool
   , intended : String
@@ -135,11 +137,12 @@ init _ =
   , closeOnSelect = False
   , deselectable = False
   , selected = Set.empty
+  , placeholder = ""
+  , emptyContent = "No items to display!"
   , searchable = False
   , multiple = False
   , disabled = False
   , readonly = False
-  , placeholder = ""
   , uid = Uid.uid ()
   , intended = ""
   , value = ""
@@ -167,6 +170,12 @@ onChange msg model =
 placeholder : String -> Model -> Model
 placeholder value model =
   { model | placeholder = value }
+
+{-| Sets the text for when there are no items to display.
+-}
+emptyContent : String -> Model -> Model
+emptyContent value model =
+  { model | emptyContent = value }
 
 
 {-| Sets whether or not to close the dropdown when selecting an item.
@@ -358,7 +367,7 @@ render model =
             , ( "disabled", model.disabled )
             , ( "readonly", model.readonly )
             ]
-          , Ui.Styles.apply defaultStyle
+          , Ui.Styles.apply (defaultStyle model.emptyContent)
           ]
           |> List.concat
         )

--- a/source/Ui/Styles/Chooser.elm
+++ b/source/Ui/Styles/Chooser.elm
@@ -14,17 +14,17 @@ import Ui.Styles exposing (Style)
 
 import Regex
 
-{-| Styles for a checkbox using the default theme.
+{-| Styles for a chooser using the default theme.
 -}
-defaultStyle : Style
-defaultStyle =
-  Ui.Styles.attributes (style Theme.default)
+defaultStyle : String -> Style
+defaultStyle emptyContent =
+  Ui.Styles.attributes <| style Theme.default emptyContent
 
 
-{-| Returns the style node for a checkbox using the given theme.
+{-| Returns the style node for a chooser using the given theme.
 -}
-style : Theme -> Node
-style theme =
+style : Theme -> String -> Node
+style theme emptyContent =
   mixin
     [ Mixins.defaults
 
@@ -112,7 +112,7 @@ style theme =
       , display flex
 
       , selector "ui-scrolled-panel-wrapper:empty:before"
-        [ contentString "No items to display!"
+        [ contentString emptyContent
         , fontStyle italic
         , padding (px 12)
         , display block

--- a/source/Ui/Styles/Chooser.elm
+++ b/source/Ui/Styles/Chooser.elm
@@ -16,15 +16,15 @@ import Regex
 
 {-| Styles for a chooser using the default theme.
 -}
-defaultStyle : String -> Style
-defaultStyle emptyContent =
-  Ui.Styles.attributes <| style Theme.default emptyContent
+defaultStyle : Style
+defaultStyle =
+  Ui.Styles.attributes <| style Theme.default
 
 
 {-| Returns the style node for a chooser using the given theme.
 -}
-style : Theme -> String -> Node
-style theme emptyContent =
+style : Theme -> Node
+style theme =
   mixin
     [ Mixins.defaults
 
@@ -110,16 +110,13 @@ style theme emptyContent =
       [ maxHeight (px 250)
       , padding (px 5)
       , display flex
-
-      , selector "ui-scrolled-panel-wrapper:empty:before"
-        [ contentString emptyContent
-        , fontStyle italic
-        , padding (px 12)
-        , display block
-        , opacity 0.5
-        ]
       ]
-
+    , selector "ui-chooser-empty-content"
+      [ fontStyle italic
+      , padding (px 12)
+      , display block
+      , opacity 0.5
+      ]
     , selector "ui-chooser-item"
       [ Mixins.ellipsis
 

--- a/source/Ui/Styles/Chooser.elm
+++ b/source/Ui/Styles/Chooser.elm
@@ -111,12 +111,14 @@ style theme =
       , padding (px 5)
       , display flex
       ]
+
     , selector "ui-chooser-empty-content"
       [ fontStyle italic
       , padding (px 12)
       , display block
       , opacity 0.5
       ]
+
     , selector "ui-chooser-item"
       [ Mixins.ellipsis
 

--- a/spec/Ui/ChooserSpec.elm
+++ b/spec/Ui/ChooserSpec.elm
@@ -27,17 +27,31 @@ specs : Node
 specs =
   describe "Ui.Chooser"
     [
+        it "Placeholder should be 'Select something...'"
+        [ assert.attributeEquals 
+            { text = "Select something..."
+            , selector = "input"
+            , attribute = "placeholder"
+            }
+        ]
     ]
+
+-- test default placeholder
+-- test if placeholder records exists
+-- change placeholder as above
+-- unit test placeholder
+
+init : Ui.Chooser.Model
+init = Ui.Chooser.init ()
+      |> Ui.Chooser.placeholder "Select something..."
+      |> Ui.Chooser.items items
+      |> Ui.Chooser.deselectable True
+      |> Ui.Chooser.multiple True
 
 main =
   runWithProgram
     { subscriptions = Ui.Chooser.subscriptions
     , update = Ui.Chooser.update
-    , init = \() ->
-      Ui.Chooser.init ()
-      |> Ui.Chooser.placeholder "Select something..."
-      |> Ui.Chooser.items items
-      |> Ui.Chooser.deselectable True
-      |> Ui.Chooser.multiple True
+    , init = \() -> init
     , view = view
     } specs

--- a/spec/Ui/ChooserSpec.elm
+++ b/spec/Ui/ChooserSpec.elm
@@ -7,13 +7,6 @@ import Ui.Chooser
 
 import Steps exposing (..)
 
-items : List Ui.Chooser.Item
-items =
-  [ { id = "0", label = "Superman", value = "superman" }
-  , { id = "1", label = "Batman", value = "batman" }
-  , { id = "2", label = "Hello", value = "hello" }
-  ]
-
 view : Ui.Chooser.Model -> Html.Html Ui.Chooser.Msg
 view model =
   Ui.Container.row []
@@ -26,25 +19,26 @@ view model =
 specs : Node
 specs =
   describe "Ui.Chooser"
-    [
-        it "Placeholder should be 'Select something...'"
+    [ it "Placeholder should be 'Select something...'"
         [ assert.attributeEquals 
             { text = "Select something..."
             , selector = "input"
             , attribute = "placeholder"
             }
         ]
+    , it "emptyContent should be 'No items.'"
+        [ assert.containsText 
+            { text = "No items."
+            , selector = "ui-chooser-empty-content"
+            }
+        ]
     ]
 
--- test default placeholder
--- test if placeholder records exists
--- change placeholder as above
--- unit test placeholder
 
 init : Ui.Chooser.Model
 init = Ui.Chooser.init ()
       |> Ui.Chooser.placeholder "Select something..."
-      |> Ui.Chooser.items items
+      |> Ui.Chooser.emptyContent (Html.text "No items.")
       |> Ui.Chooser.deselectable True
       |> Ui.Chooser.multiple True
 


### PR DESCRIPTION
With the emptyContent field it's possible to change the text that's being displayed when there are no items to select. 
![elm-chooser-empty-content](https://cloud.githubusercontent.com/assets/1347371/23811607/fd3d60f4-05d6-11e7-9809-69e55c88438a.png)
