### PR TITLE
Return dummy patchStyles function if document is not defined

### DIFF
--- a/source/Native/Styles.js
+++ b/source/Native/Styles.js
@@ -1,4 +1,8 @@
 var _gdotdesign$elm_ui$Native_Styles = function() {
+  if(typeof document === "undefined") {
+    return {patchStyles: function() {}};
+  }
+
   var currentStyles = {}
 
   var setupObserver = function () {


### PR DESCRIPTION
This fixes an error when using `elm-ui` with https://github.com/rtfeldman/elm-css.
Running `elm-css` resulted in the following error without this fix:

	Error: ReferenceError: document is not defined

This happened because `elm-css` is run using node when generating the css output and it doesn't have `document` defined.