### PR TITLE
Set window to dummy object if not defined

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -77,7 +77,6 @@
     "coreytrampe/elm-vendor": "2.0.3 <= v < 3.0.0",
     "rluiten/elm-date-extra": "8.0.0 <= v < 9.0.0",
     "elm-lang/virtual-dom": "2.0.0 <= v < 3.0.0",
-    "gdotdesign/elm-spec": "1.1.0 <= v <= 2.0.0",
     "gdotdesign/elm-dom": "1.0.0 <= v < 2.0.0",
     "ggb/numeral-elm": "1.2.1 <= v < 2.0.0",
     "Skinney/murmur3": "2.0.4 <= v < 3.0.0",

--- a/source/Native/FileManager.js
+++ b/source/Native/FileManager.js
@@ -1,3 +1,7 @@
+if(typeof window === "undefined") {
+  var window = {};
+}
+
 //download.js v4.1, by dandavis; 2008-2015. [CCBY2] see http://danml.com/download.html for tests/usage
 window.download = function(data, strFileName, strMimeType) {
   var self = window, // this script is only for browsers anyway...


### PR DESCRIPTION
This fixes an error when using elm-ui with rtfeldman/elm-css.
Similar to e778f0aa1aff6cb62c9bc7434173725350947a0f